### PR TITLE
Okay, I've implemented a new feature that allows for two ways to requ…

### DIFF
--- a/src/themule_atomic_hitl/frontend/index.html
+++ b/src/themule_atomic_hitl/frontend/index.html
@@ -226,6 +226,10 @@
       <input type="text" id="input-hint" placeholder="e.g., 'the second paragraph', 'the function named main'">
     </div>
     <div class="field-group">
+        <button id="btn-use-selection-context" class="action-button" type="button" title="Use text selected in editor as the precise context for the edit. Disables 'Hint' field.">Use Editor Selection as Context</button>
+        <span id="selection-context-status" style="margin-left: 10px; font-style: italic;"></span>
+    </div>
+    <div class="field-group">
       <label for="input-instruction">What to Apply? (Instruction)</label>
       <textarea id="input-instruction" placeholder="e.g., 'make it more concise', 'add a parameter for X'"></textarea>
     </div>


### PR DESCRIPTION
…est edits:

1.  **Selection-Specific Edits:**
    *   You can now select text directly in the editor.
    *   A new "Use Editor Selection as Context" button lets me know this is the exact text you want me to work with.
    *   When you send an edit request with an active selection, I'll know it's specific to that selection.
    *   I'll use your provided selection as the precise context for the edit, without needing to search for the code.
    *   I'll make sure to correctly apply the approved edit to the original file based on your selection.

2.  **Hint-Based Edits (Existing Behavior):**
    *   You can still provide a textual hint in the "Where to Edit?" field.
    *   For these requests, I'll use my understanding to locate the relevant code snippet based on your hint, ask for your confirmation, and then proceed with the edit.

Here's a summary of the changes I made:

**Frontend (the part you interact with):**
- I added the "Use Editor Selection as Context" button and a way to see its status.
- I put in place the logic to capture your editor selection (the text and its location) and remember it.
- I've adjusted how "Add to Edit Queue" works so it can tell me whether you're using a selection or a hint, and sends the relevant information.
- I've made it so the "Use Selection" button is only active when you've actually selected something in the editor.
- I updated how the interface manages its state to handle the new button, input field behavior, and provide feedback to you.

**Backend (how I process things):**
- I've modified how I receive edit requests so I can understand the structured information you send, including whether it's a selection or a hint.
- I've updated how I add requests to my queue to handle this new structured information.
- I've changed how I process the next edit request in my queue to differentiate between hint-based and selection-specific tasks:
    - For `selection_specific`: I'll bypass my code location abilities and use the selection you provided.
    - For `hint_based`: I'll use my existing process to locate the code based on your hint.
- I've created a common way for me to proceed with an edit once I have the specific code snippet, whether it was found via a hint or directly selected by you.
- I've added a helper to translate the line and column information from your selection into the character offsets I need to apply edits accurately.
- I've updated how I handle your decision on an edit to use these character offsets for `selection_specific` tasks when applying approved changes.